### PR TITLE
Fix capitalization in require call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
     ShipConfirm: require('./lib/shipConfirm'),
     ShipAccept: require('./lib/shipAccept'),
-    AddressValidation: require('./lib/AddressValidation'),
+    AddressValidation: require('./lib/addressValidation'),
     VoidShipment: require('./lib/voidShipment'),
     TimeInTransit: require('./lib/timeInTransit'),
     Rating: require('./lib/rating'),


### PR DESCRIPTION
OSX is forgiving about module capitalisation, Linux less so. This change makes the module work on Linux as well.
